### PR TITLE
Downloading CSL styles directly from github. Ability to switch origins.

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -14,7 +14,7 @@ var CSLStyles = function(){
 	
 	// CSL file can be loaded from local file or from GitHub
 	//var CSL_ORIGIN = "../styles/";
-	var CSL_ORIGIN = "https://rawgit.com/itation-style-language/styles/master/";
+	var CSL_ORIGIN = "https://rawgit.com/citation-style-language/styles/master/";
 	
 	var availableStyles =
 	["academy-of-management-review"

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -11,7 +11,11 @@
 
 //initial list generated from styles repo with ls styles/*csl | sed s:styles/:,\": | sed s:.csl:\":
 var CSLStyles = function(){
-
+	
+	// CSL file can be loaded from local file or from GitHub
+	//var CSL_ORIGIN = "../styles/";
+	var CSL_ORIGIN = "https://rawgit.com/itation-style-language/styles/master/";
+	
 	var availableStyles =
 	["academy-of-management-review"
 	,"acm-sig-proceedings-long-author-list"
@@ -1249,7 +1253,8 @@ var CSLStyles = function(){
 		if ($.inArray(styleName, availableStyles) > -1){
 			$.ajax({
 					type: "GET",
-		            url: "../styles/"+styleName+".csl",
+		            //url: "../styles/" + styleName + ".csl",
+					url:  CSL_ORIGIN + styleName + ".csl",
 		            dataType: "text",
 		            success: function (data) {
 		            	callback(data);


### PR DESCRIPTION
Downloading CSL styles directly from github. Ability to switch between different origins (local, remote). Allows to overcome following error: 
**XMLHttpRequest cannot load ...styles/ieee.csl. Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, https, chrome-extension-resource.**
